### PR TITLE
Change restarting unix after changing .bashrc to restarting the shell

### DIFF
--- a/Doc/Git-classroom-guide-for-student.md
+++ b/Doc/Git-classroom-guide-for-student.md
@@ -23,7 +23,7 @@ Below will describe the simplified procedure of how to use git classroom to do l
     3. press PageDown until you are at last line. Enter to a new line
     4. Key in "export GIT_USER=xxxx" without quote and extra space
     5. Prese Esc, then enter ":x" without quote, press enter
-    6. Restart unix kernel
+    6. Restart the `bash` or type `bash` to start a new shell in order to make the change effective
     
 * At the lab, go to your unix home directory, and run below command to download scripts for setting up of local assignment repository, and submit the work back to git:
     ```sh


### PR DESCRIPTION
I think restarting the system after exporting the `GIT_USER` environment variable in `.bashrc` is unnecessary. It's also unrealistic for them to restart the servers.

Besides the method I propose, students can also do the following and normally should work, but I found restarting the shell might be the safest:
1. `source ~/.bashrc` (depends on their `.bashrc` which might break)

